### PR TITLE
Create publish-older-glibc.sh

### DIFF
--- a/scripts/publish-older-glibc.sh
+++ b/scripts/publish-older-glibc.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+docker run --rm --user "$(id -u)":"$(id -g)" -v "$PWD":/usr/src/myapp -w /usr/src/myapp rust:1.65-buster ./scripts/publish-x86-64-Linux.sh


### PR DESCRIPTION
Closes #106
In order to use app on older systems, we can use docker, instead of statically linking glibc.
This PR adds script to publish x64, but utilizing docker with Debian 10 image, which uses [glibc v2.28](https://packages.debian.org/buster/libc6-amd64)